### PR TITLE
Update to Node 9 for Asset Building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - run: apt-get update && apt-get install -y curl python build-essential git
       - checkout
-      - run: curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+      - run: curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
       - run: apt-get update && apt-get install -y nodejs
       - run: apt-get install -y pkg-config libssl-dev
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 8
+  - 9
 
 sudo: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   NODE_PRE_GYP_GITHUB_TOKEN:
     secure: 97nEGQD8WunBmL8rjt0lmk4LC34NhaNE9DDSTFudznlgTJaeclY/H1iOn+oh4Yy4
-  nodejs_version: 8
+  nodejs_version: 9
   rust_channel: stable
   matrix:
     - platform: x64


### PR DESCRIPTION
The Heroku CLI is now running Node 9.4.0. The Node ABI changed from 57 to 59 from Node 8.1.0 -> 9.